### PR TITLE
[A1-1] ジャンルを仮で選べるようにした。

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { CreateAccountPage } from "./components/pages/CreateAccountPage";
 import { FindRecipePage } from "./components/pages/FindRecipePage";
 import { RecipeDetailPage } from "./components/pages/RecipeDetailPage";
 import { PostRecipePage } from "./components/pages/PostRecipePage";
+import { RecipeListPage } from "./components/pages/RecipeListPage";
 
 import { TitleBar } from "./components/common/TitleBar";
 
@@ -18,7 +19,7 @@ function App() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/create-account" element={<CreateAccountPage />} />
           <Route path="/find" element={<FindRecipePage />} />
-          <Route path="/recipe-list" element={<FindRecipePage />} />
+          <Route path="/recipe-list" element={<RecipeListPage />} />
           <Route path="/recipe-detail" element={<RecipeDetailPage />} />
           <Route path="/post" element={<PostRecipePage />} />
         </Routes>

--- a/src/components/features/findRecipe/FindFromGenre.tsx
+++ b/src/components/features/findRecipe/FindFromGenre.tsx
@@ -1,3 +1,66 @@
+import { Genre } from "../../types/genre";
+import { Typography, Stack } from "@mui/material";
+import { Card, CardOverflow, AspectRatio, CardContent } from "@mui/joy";
+
 export const FindFromGenre = () => {
-  return <p>ジャンルから探す</p>;
+  const sampleGenreList: Genre[] = [
+    {
+      id: 1,
+      genre: "風景",
+    },
+    {
+      id: 2,
+      genre: "人物",
+    },
+    {
+      id: 3,
+      genre: "料理",
+    },
+    {
+      id: 4,
+      genre: "動物",
+    },
+    {
+      id: 5,
+      genre: "建物",
+    },
+    {
+      id: 6,
+      genre: "その他",
+    },
+  ];
+
+  return (
+    <div>
+      <Stack direction="column" spacing={2}>
+        {sampleGenreList.map((genre) => (
+          <Card
+            orientation="horizontal"
+            sx={{
+              width: "90%",
+              margin: "auto",
+              backgroundColor: "#ffffff",
+              cursor: "pointer",
+            }}
+          >
+            <CardOverflow>
+              <AspectRatio ratio="1" sx={{ width: 90 }}>
+                <img
+                  src="https://images.unsplash.com/photo-1507833423370-a126b89d394b?auto=format&fit=crop&w=90"
+                  srcSet="https://images.unsplash.com/photo-1507833423370-a126b89d394b?auto=format&fit=crop&w=90&dpr=2 2x"
+                  loading="lazy"
+                  alt=""
+                />
+              </AspectRatio>
+            </CardOverflow>
+            <CardContent>
+              <Typography gutterBottom variant="h5" component="div">
+                {genre.genre}
+              </Typography>
+            </CardContent>
+          </Card>
+        ))}
+      </Stack>
+    </div>
+  );
 };

--- a/src/components/features/findRecipe/FindFromGenre.tsx
+++ b/src/components/features/findRecipe/FindFromGenre.tsx
@@ -2,6 +2,8 @@ import { Genre } from "../../types/genre";
 import { Typography, Stack } from "@mui/material";
 import { Card, CardOverflow, AspectRatio, CardContent } from "@mui/joy";
 
+import { Link } from "react-router-dom";
+
 export const FindFromGenre = () => {
   const sampleGenreList: Genre[] = [
     {
@@ -34,31 +36,37 @@ export const FindFromGenre = () => {
     <div>
       <Stack direction="column" spacing={2}>
         {sampleGenreList.map((genre) => (
-          <Card
-            orientation="horizontal"
-            sx={{
-              width: "90%",
-              margin: "auto",
-              backgroundColor: "#ffffff",
-              cursor: "pointer",
-            }}
+          <Link
+            to={"/recipe-list"}
+            state={{ genreId: genre.id }}
+            style={{ borderStyle: "none" }}
           >
-            <CardOverflow>
-              <AspectRatio ratio="1" sx={{ width: 90 }}>
-                <img
-                  src="https://images.unsplash.com/photo-1507833423370-a126b89d394b?auto=format&fit=crop&w=90"
-                  srcSet="https://images.unsplash.com/photo-1507833423370-a126b89d394b?auto=format&fit=crop&w=90&dpr=2 2x"
-                  loading="lazy"
-                  alt=""
-                />
-              </AspectRatio>
-            </CardOverflow>
-            <CardContent>
-              <Typography gutterBottom variant="h5" component="div">
-                {genre.genre}
-              </Typography>
-            </CardContent>
-          </Card>
+            <Card
+              orientation="horizontal"
+              sx={{
+                width: "90%",
+                margin: "auto",
+                backgroundColor: "#ffffff",
+                cursor: "pointer",
+              }}
+            >
+              <CardOverflow>
+                <AspectRatio ratio="1" sx={{ width: 90 }}>
+                  <img
+                    src="https://images.unsplash.com/photo-1507833423370-a126b89d394b?auto=format&fit=crop&w=90"
+                    srcSet="https://images.unsplash.com/photo-1507833423370-a126b89d394b?auto=format&fit=crop&w=90&dpr=2 2x"
+                    loading="lazy"
+                    alt=""
+                  />
+                </AspectRatio>
+              </CardOverflow>
+              <CardContent>
+                <Typography gutterBottom variant="h5" component="div">
+                  {genre.genre}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Link>
         ))}
       </Stack>
     </div>

--- a/src/components/features/findRecipe/FindFromGenre.tsx
+++ b/src/components/features/findRecipe/FindFromGenre.tsx
@@ -1,0 +1,3 @@
+export const FindFromGenre = () => {
+  return <p>ジャンルから探す</p>;
+};

--- a/src/components/features/findRecipe/FindFromPickUp.tsx
+++ b/src/components/features/findRecipe/FindFromPickUp.tsx
@@ -1,0 +1,3 @@
+export const FindFromPickUp = () => {
+  return <p>ピックアップから探す</p>;
+};

--- a/src/components/features/findRecipe/FindRecipe.tsx
+++ b/src/components/features/findRecipe/FindRecipe.tsx
@@ -1,7 +1,53 @@
+import { Typography, Box } from "@mui/material";
+import { Input, Tabs, TabList, tabClasses, Tab, TabPanel } from "@mui/joy";
+import { FindFromGenre } from "./FindFromGenre";
+import { FindFromPickUp } from "./FindFromPickUp";
+
 export const FindRecipe = () => {
   return (
     <div>
-      <h1>FindRecipe</h1>
+      <Box
+        sx={{
+          flexGrow: 1,
+          marginTop: "20px",
+          width: "90%",
+          marginLeft: "auto",
+          marginRight: "auto",
+        }}
+      >
+        <Typography variant="h3" component="div" sx={{ flexGrow: 1 }}>
+          さがす
+        </Typography>
+        <Input variant="soft" placeholder="例：桜、夕陽、正月" />
+        <Tabs
+          aria-label="tabs"
+          defaultValue={0}
+          sx={{ bgcolor: "transparent", marginTop: "20px" }}
+        >
+          <TabList
+            disableUnderline
+            sx={{
+              p: 0.5,
+              gap: 0.5,
+              borderRadius: "xl",
+              bgcolor: "background.level1",
+              [`& .${tabClasses.root}[aria-selected="true"]`]: {
+                boxShadow: "sm",
+                bgcolor: "background.surface",
+              },
+            }}
+          >
+            <Tab disableIndicator>ピックアップ</Tab>
+            <Tab disableIndicator>ジャンル</Tab>
+          </TabList>
+          <TabPanel value={0}>
+            <FindFromPickUp />
+          </TabPanel>
+          <TabPanel value={1}>
+            <FindFromGenre />
+          </TabPanel>
+        </Tabs>
+      </Box>
     </div>
   );
 };

--- a/src/components/features/recipeList/RecipeList.tsx
+++ b/src/components/features/recipeList/RecipeList.tsx
@@ -1,7 +1,12 @@
+import { useLocation } from "react-router-dom";
+
 export const RecipeList = () => {
+  const location = useLocation();
+  const { genreId } = location.state;
   return (
     <div>
       <h1>RecipeList</h1>
+      <p>genreId: {genreId}</p>
     </div>
   );
 };

--- a/src/components/types/genre.ts
+++ b/src/components/types/genre.ts
@@ -1,0 +1,4 @@
+export type Genre = {
+  id: number;
+  genre: string;
+};


### PR DESCRIPTION
# Changes
- Genreの型ファイルを定義した。`components/types/genre.ts`
- 仮のGenreデータをリストで持ち、それを元にリストとして表示できるようにした。 `omponents/features/findRecipe/FindFromGenre.tsx`
- ルーターのバグを修正した
- genreIdを、レシピのリスト画面に渡せるようにした。

# How to test
1. npm run dev
2. `/find`にアクセスして以下を確認
* ジャンルタブに切り替えると、仮のジャンルの一覧が出てくる
* 各ジャンルをクリックすると、そのジャンルのidが`recipe-list`に渡されて、genreIdの右側に表示される
# Not completed
* タブの横幅が広くなってしまう問題の解消

# Reference
<img src="https://github.com/Teclub200/SnapMinds_FRONT/assets/85172807/0da9b2a7-6576-43d5-a2cf-2a78bfd8f109" width="50%">

# Issue
closed #19 
<!--If you want to close the issue -> closed #{issue No.}-->
<!--If you want to create relation only -> #{issue No.} -->
